### PR TITLE
add support for 'require-sri-for' CSP directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ SecureHeaders::Configuration.default do |config|
     media_src: %w(utoob.com),
     object_src: %w('self'),
     plugin_types: %w(application/x-shockwave-flash),
+    require_sri_for: %w(script style),
     script_src: %w('self'),
     style_src: %w('unsafe-inline'),
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -8,6 +8,7 @@ module SecureHeaders
 
     # constants to be used for version-specific UA sniffing
     VERSION_46 = ::UserAgent::Version.new("46")
+    VERSION_50 = ::UserAgent::Version.new("50")
 
     def initialize(config = nil, user_agent = OTHER)
       @config = Configuration.send(:deep_copy, config || DEFAULT_CONFIG)
@@ -186,15 +187,13 @@ module SecureHeaders
     #
     # Returns an array of symbols representing the directives.
     def supported_directives
-      @supported_directives ||= if VARIATIONS[@parsed_ua.browser]
-        if @parsed_ua.browser == "Firefox" && @parsed_ua.version >= VERSION_46
-          VARIATIONS["FirefoxTransitional"]
-        else
-          VARIATIONS[@parsed_ua.browser]
+      @supported_directives ||= if @parsed_ua.browser == "Firefox"
+        if @parsed_ua.version >= VERSION_50
+          VARIATIONS["Firefox50"]
+        elsif @parsed_ua.version >= VERSION_46
+          VARIATIONS["Firefox46"]
         end
-      else
-        VARIATIONS[OTHER]
-      end
+      end || VARIATIONS[@parsed_ua.browser] || VARIATIONS[OTHER]
     end
 
     def nonces_supported?

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -52,6 +52,7 @@ module SecureHeaders
     FORM_ACTION = :form_action
     FRAME_ANCESTORS = :frame_ancestors
     PLUGIN_TYPES = :plugin_types
+    REQUIRE_SRI_FOR = :require_sri_for
 
     # These are directives that do not inherit the default-src value. This is
     # useful when calling #combine_policies.
@@ -60,7 +61,8 @@ module SecureHeaders
       FORM_ACTION,
       FRAME_ANCESTORS,
       PLUGIN_TYPES,
-      REPORT_URI
+      REPORT_URI,
+      REQUIRE_SRI_FOR
     ]
 
     DIRECTIVES_2_0 = [
@@ -88,26 +90,23 @@ module SecureHeaders
     UPGRADE_INSECURE_REQUESTS = :upgrade_insecure_requests
     DIRECTIVES_DRAFT = [
       BLOCK_ALL_MIXED_CONTENT,
-      UPGRADE_INSECURE_REQUESTS
+      UPGRADE_INSECURE_REQUESTS,
+      REQUIRE_SRI_FOR
     ].freeze
-
-    EDGE_DIRECTIVES = DIRECTIVES_1_0
-    SAFARI_DIRECTIVES = DIRECTIVES_1_0
 
     FIREFOX_UNSUPPORTED_DIRECTIVES = [
       BLOCK_ALL_MIXED_CONTENT,
       CHILD_SRC,
-      PLUGIN_TYPES
+      PLUGIN_TYPES,
+      REQUIRE_SRI_FOR
     ].freeze
 
     FIREFOX_46_DEPRECATED_DIRECTIVES = [
       FRAME_SRC
     ].freeze
 
-    FIREFOX_46_UNSUPPORTED_DIRECTIVES = [
-      BLOCK_ALL_MIXED_CONTENT,
-      PLUGIN_TYPES
-    ].freeze
+    FIREFOX_46_UNSUPPORTED_DIRECTIVES = FIREFOX_UNSUPPORTED_DIRECTIVES - [CHILD_SRC]
+    FIREFOX_50_UNSUPPORTED_DIRECTIVES = FIREFOX_46_UNSUPPORTED_DIRECTIVES - [REQUIRE_SRI_FOR]
 
     FIREFOX_DIRECTIVES = (
       DIRECTIVES_2_0 + DIRECTIVES_DRAFT - FIREFOX_UNSUPPORTED_DIRECTIVES
@@ -117,9 +116,16 @@ module SecureHeaders
       DIRECTIVES_2_0 + DIRECTIVES_DRAFT - FIREFOX_46_UNSUPPORTED_DIRECTIVES - FIREFOX_46_DEPRECATED_DIRECTIVES
     ).freeze
 
+    FIREFOX_50_DIRECTIVES = (
+      DIRECTIVES_2_0 + DIRECTIVES_DRAFT - FIREFOX_50_UNSUPPORTED_DIRECTIVES - FIREFOX_46_DEPRECATED_DIRECTIVES
+    ).freeze
+
     CHROME_DIRECTIVES = (
       DIRECTIVES_2_0 + DIRECTIVES_DRAFT
     ).freeze
+
+    EDGE_DIRECTIVES = DIRECTIVES_1_0
+    SAFARI_DIRECTIVES = DIRECTIVES_1_0
 
     ALL_DIRECTIVES = [DIRECTIVES_1_0 + DIRECTIVES_2_0 + DIRECTIVES_3_0 + DIRECTIVES_DRAFT].flatten.uniq.sort
 
@@ -131,7 +137,8 @@ module SecureHeaders
       "Chrome" => CHROME_DIRECTIVES,
       "Opera" => CHROME_DIRECTIVES,
       "Firefox" => FIREFOX_DIRECTIVES,
-      "FirefoxTransitional" => FIREFOX_46_DIRECTIVES,
+      "Firefox46" => FIREFOX_46_DIRECTIVES,
+      "Firefox50" => FIREFOX_50_DIRECTIVES,
       "Safari" => SAFARI_DIRECTIVES,
       "Edge" => EDGE_DIRECTIVES,
       "Other" => CHROME_DIRECTIVES
@@ -156,6 +163,7 @@ module SecureHeaders
       PLUGIN_TYPES              => :source_list,
       REFLECTED_XSS             => :string,
       REPORT_URI                => :source_list,
+      REQUIRE_SRI_FOR           => :source_list,
       SANDBOX                   => :string,
       SCRIPT_SRC                => :source_list,
       STYLE_SRC                 => :source_list,

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -116,28 +116,34 @@ module SecureHeaders
             upgrade_insecure_requests: true,
             reflected_xss: "block",
             script_src: %w(script-src.com),
-            script_nonce: 123456
+            script_nonce: 123456,
+            require_sri_for: %w(script style)
           })
         end
 
         it "does not filter any directives for Chrome" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:chrome])
-          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; plugin-types plugin-types.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; plugin-types plugin-types.com; require-sri-for script style; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
         end
 
         it "does not filter any directives for Opera" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:opera])
-          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; plugin-types plugin-types.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; plugin-types plugin-types.com; require-sri-for script style; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
         end
 
-        it "filters blocked-all-mixed-content, child-src, and plugin-types for firefox" do
+        it "filters require-sri-for, blocked-all-mixed-content, child-src, and plugin-types for firefox" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:firefox])
           expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; frame-src child-src.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
         end
 
-        it "filters blocked-all-mixed-content, frame-src, and plugin-types for firefox 46 and higher" do
+        it "filters require-sri-for, blocked-all-mixed-content, frame-src, and plugin-types for firefox 46 - 49" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:firefox46])
           expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+        end
+
+        it "filters blocked-all-mixed-content, frame-src, and plugin-types for firefox 50 and higher" do
+          policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:firefox50])
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; require-sri-for script style; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
         end
 
         it "child-src value is copied to frame-src, adds 'unsafe-inline', filters base-uri, blocked-all-mixed-content, upgrade-insecure-requests, child-src, form-action, frame-ancestors, nonce sources, hash sources, and plugin-types for Edge" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ USER_AGENTS = {
   edge: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246",
   firefox: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:14.0) Gecko/20100101 Firefox/14.0.1",
   firefox46: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0",
+  firefox50: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:50.0) Gecko/20100101 Firefox/50.0",
   chrome: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5',
   ie: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/5.0)',
   opera: 'Opera/9.80 (Windows NT 6.1; U; es-ES) Presto/2.9.181 Version/12.00',


### PR DESCRIPTION
Fixes #264
## All PRs:
- [x] Has tests
- [x] Documentation updated
## Adding a new CSP directive
- Is the directive supported by any user agent? If so, which?
  - Chrome vSomething, Firefox 50+
- What does it do?
  - Ensures that all assets (scripts and styles for now) loaded have a valid integrity attribute per SRI
- What are the valid values for the directive?
  - `script` and `style` for now (unquoted, right?)

See https://codereview.chromium.org/2056183002/ and https://frederik-braun.com/new-csp-directive-to-make-subresource-integrity-mandatory-require-sri-for.html and https://gist.github.com/mozfreddyb/f4b7e79ab629a3ecff663f33d9a56e82

/cc https://github.com/w3c/webappsec-subresource-integrity/pull/32
