### PR TITLE
Add option to disable appending 'unsafe-inline' when using nonces

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -179,7 +179,8 @@ module SecureHeaders
     # unsafe-inline, this is more concise.
     def append_nonce(source_list, nonce)
       if nonce
-        source_list.push("'nonce-#{nonce}'", UNSAFE_INLINE)
+        source_list.push("'nonce-#{nonce}'")
+        source_list.push(UNSAFE_INLINE) unless @config[:disable_nonce_backwards_compatibility]
       end
 
       source_list

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -42,6 +42,7 @@ module SecureHeaders
       @style_src = nil
       @worker_src = nil
       @upgrade_insecure_requests = nil
+      @disable_nonce_backwards_compatibility = nil
 
       from_hash(hash)
     end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -153,7 +153,8 @@ module SecureHeaders
 
     META_CONFIGS = [
       :report_only,
-      :preserve_schemes
+      :preserve_schemes,
+      :disable_nonce_backwards_compatibility
     ].freeze
 
     NONCES = [

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -145,6 +145,11 @@ module SecureHeaders
         csp = ContentSecurityPolicy.new({default_src: %w('self'), script_src: [ContentSecurityPolicy::STRICT_DYNAMIC], script_nonce: 123456})
         expect(csp.value).to eq("default-src 'self'; script-src 'strict-dynamic' 'nonce-123456' 'unsafe-inline'")
       end
+
+      it "supports strict-dynamic and opting out of the appended 'unsafe-inline'" do
+        csp = ContentSecurityPolicy.new({default_src: %w('self'), script_src: [ContentSecurityPolicy::STRICT_DYNAMIC], script_nonce: 123456, disable_nonce_backwards_compatibility: true })
+        expect(csp.value).to eq("default-src 'self'; script-src 'strict-dynamic' 'nonce-123456'")
+      end
     end
   end
 end


### PR DESCRIPTION
This is in reference to #403
