### PR TITLE
Fix references to OPT_OUT constant

### DIFF
--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -25,7 +25,7 @@ Boolean-based configuration is intended to globally enable or disable a specific
 ```ruby
 config.cookies = {
   secure: true, # mark all cookies as Secure
-  httponly: OPT_OUT, # do not mark any cookies as HttpOnly
+  httponly: SecureHeaders::OPT_OUT, # do not mark any cookies as HttpOnly
 }
 ```
 

--- a/docs/upgrading-to-6-0.md
+++ b/docs/upgrading-to-6-0.md
@@ -5,7 +5,7 @@ The original implementation of name overrides worked by making a copy of the def
 ```ruby
 class ApplicationController < ActionController::Base
   Configuration.default do |config|
-    config.x_frame_options = OPT_OUT
+    config.x_frame_options = SecureHeaders::OPT_OUT
   end
 
   SecureHeaders::Configuration.override(:dynamic_override) do |config|


### PR DESCRIPTION
Without `SecureHeaders::`, this will raise `uninitialized constant` error, this Pull Request fixes it.

## All PRs:

* [ ] Has tests
* [x] Documentation updated

