### PR TITLE
Escape semi colons in directive source lists in 3.x releases

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -142,8 +142,14 @@ module SecureHeaders
         @config.directive_value(directive)
       end
       return unless source_list && source_list.any?
-      normalized_source_list = minify_source_list(directive, source_list)
-      [symbol_to_hyphen_case(directive), normalized_source_list].join(" ")
+      normalized_source_list = minify_source_list(directive, source_list).join(" ")
+
+      if normalized_source_list.include?(";")
+        Kernel.warn("#{directive} contains a ; in '#{normalized_source_list}' which will raise an error in future versions. It has been replaced with a blank space.")
+      end
+      escaped_source_list = normalized_source_list.gsub(";", " ")
+
+      [symbol_to_hyphen_case(directive), escaped_source_list].join(" ").strip
     end
 
     # If a directive contains *, all other values are omitted.

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -23,6 +23,15 @@ module SecureHeaders
     end
 
     describe "#value" do
+      it "uses a safe but non-breaking default value" do
+        expect(ContentSecurityPolicy.new.value).to eq("default-src https:")
+      end
+
+      it "deprecates and escapes semicolons in directive source lists" do
+        expect(Kernel).to receive(:warn).with("frame_ancestors contains a ; in 'google.com;script-src *;.;' which will raise an error in future versions. It has been replaced with a blank space.")
+        expect(ContentSecurityPolicy.new(frame_ancestors: %w(https://google.com;script-src https://*;.;)).value).to eq("frame-ancestors google.com script-src * .")
+      end
+
       it "discards 'none' values if any other source expressions are present" do
         csp = ContentSecurityPolicy.new(default_opts.merge(child_src: %w('self' 'none')))
         expect(csp.value).not_to include("'none'")


### PR DESCRIPTION
See https://github.com/twitter/secure_headers/issues/418 

I think there's a fair amount of people on the 3.x line, this is a backport of https://github.com/twitter/secure_headers/pull/419