### PR TITLE
escape semicolons by replacing them with spaces for 5.x line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 
 rvm:
   - ruby-head
-  - 2.4.2
-  - 2.3.5
-  - 2.2.8
+  - 2.6
+  - 2.4
+  - 2.4
   - jruby-head
 
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :test do
   gem "pry-nav"
   gem "rack"
   gem "rspec"
-  gem "rubocop"
+  gem "rubocop", "< 0.68"
   gem "rubocop-github"
   gem "term-ansicolor"
   gem "tins"

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -138,8 +138,14 @@ module SecureHeaders
       end
 
       if source_list != OPT_OUT && source_list && source_list.any?
-        normalized_source_list = minify_source_list(directive, source_list)
-        [symbol_to_hyphen_case(directive), normalized_source_list].join(" ")
+        minified_source_list = minify_source_list(directive, source_list).join(" ")
+
+        if minified_source_list.include?(";")
+          Kernel.warn("#{directive} contains a ; in '#{minified_source_list}' which will raise an error in future versions. It has been replaced with a blank space.")
+        end
+
+        escaped_source_list = minified_source_list.gsub(";", " ")
+        [symbol_to_hyphen_case(directive), escaped_source_list].join(" ").strip
       end
     end
 

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -28,6 +28,11 @@ module SecureHeaders
         expect(ContentSecurityPolicy.new.value).to eq("default-src https:; form-action 'self'; img-src https: data: 'self'; object-src 'none'; script-src https:; style-src 'self' 'unsafe-inline' https:")
       end
 
+      it "deprecates and escapes semicolons in directive source lists" do
+        expect(Kernel).to receive(:warn).with("frame_ancestors contains a ; in 'google.com;script-src *;.;' which will raise an error in future versions. It has been replaced with a blank space.")
+        expect(ContentSecurityPolicy.new(frame_ancestors: %w(https://google.com;script-src https://*;.;)).value).to eq("frame-ancestors google.com script-src * .")
+      end
+
       it "discards 'none' values if any other source expressions are present" do
         csp = ContentSecurityPolicy.new(default_opts.merge(child_src: %w('self' 'none')))
         expect(csp.value).not_to include("'none'")


### PR DESCRIPTION
See https://github.com/twitter/secure_headers/issues/418

Backport of https://github.com/twitter/secure_headers/issues/419