### PR TITLE
Move semicolon/newline handling to validation and raise errors

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -105,13 +105,7 @@ module SecureHeaders
       source_list = @config.directive_value(directive)
       if source_list != OPT_OUT && source_list && source_list.any?
         minified_source_list = minify_source_list(directive, source_list).join(" ")
-
-        if minified_source_list =~ /(\n|;)/
-          Kernel.warn("#{directive} contains a #{$1} in #{minified_source_list.inspect} which will raise an error in future versions. It has been replaced with a blank space.")
-        end
-
-        escaped_source_list = minified_source_list.gsub(/[\n;]/, " ")
-        [symbol_to_hyphen_case(directive), escaped_source_list].join(" ").strip
+        [symbol_to_hyphen_case(directive), minified_source_list].join(" ").strip
       end
     end
 

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -164,6 +164,10 @@ module SecureHeaders
 
     REQUIRE_SRI_FOR_VALUES = Set.new(%w(script style))
 
+    # These values are not valid in a policy and can be used to escape context
+    # boundaries
+    ESCAPE_SEQUENCE = /(\n|;)/
+
     module ClassMethods
       # Public: generate a header name, value array that is user-agent-aware.
       #
@@ -386,6 +390,10 @@ module SecureHeaders
         source_expression.each do |expression|
           if ContentSecurityPolicy::DEPRECATED_SOURCE_VALUES.include?(expression)
             raise ContentSecurityPolicyConfigError.new("#{directive} contains an invalid keyword source (#{expression}). This value must be single quoted.")
+          end
+
+          if expression =~ ESCAPE_SEQUENCE
+            raise ContentSecurityPolicyConfigError.new("#{directive} contains a #{$1.inspect} in #{expression.inspect}")
           end
         end
       end

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -28,16 +28,6 @@ module SecureHeaders
         expect(ContentSecurityPolicy.new.value).to eq("default-src https:; form-action 'self'; img-src https: data: 'self'; object-src 'none'; script-src https:; style-src 'self' 'unsafe-inline' https:")
       end
 
-      it "deprecates and escapes semicolons in directive source lists" do
-        expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a ; in "google.com;script-src *;.;" which will raise an error in future versions. It has been replaced with a blank space.))
-        expect(ContentSecurityPolicy.new(frame_ancestors: %w(https://google.com;script-src https://*;.;)).value).to eq("frame-ancestors google.com script-src * .")
-      end
-
-      it "deprecates and escapes semicolons in directive source lists" do
-        expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a \n in "\\nfoo.com\\nhacked" which will raise an error in future versions. It has been replaced with a blank space.))
-        expect(ContentSecurityPolicy.new(frame_ancestors: ["\nfoo.com\nhacked"]).value).to eq("frame-ancestors  foo.com hacked")
-      end
-
       it "discards 'none' values if any other source expressions are present" do
         csp = ContentSecurityPolicy.new(default_opts.merge(child_src: %w('self' 'none')))
         expect(csp.value).not_to include("'none'")

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -59,13 +59,13 @@ module SecureHeaders
       it "requires a :default_src value" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(script_src: %w('self')))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, ":default_src is required")
       end
 
       it "requires a :script_src value" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_src: %w('self')))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, ":script_src is required, falling back to default-src is too dangerous. Use `script_src: OPT_OUT` to override")
       end
 
       it "accepts OPT_OUT as a script-src value" do
@@ -76,32 +76,44 @@ module SecureHeaders
 
       it "requires :report_only to be a truthy value" do
         expect do
-          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(report_only: "steve")))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyReportOnlyConfig.new(default_opts.merge(report_only: "steve")))
+        end.to raise_error(ContentSecurityPolicyConfigError, "report_only must be a boolean value")
       end
 
       it "requires :preserve_schemes to be a truthy value" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(preserve_schemes: "steve")))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, "preserve_schemes must be a boolean value")
       end
 
       it "requires :block_all_mixed_content to be a boolean value" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(block_all_mixed_content: "steve")))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, "block_all_mixed_content must be a boolean. Found String value")
       end
 
       it "requires :upgrade_insecure_requests to be a boolean value" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(upgrade_insecure_requests: "steve")))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, "upgrade_insecure_requests must be a boolean. Found String value")
       end
 
       it "requires all source lists to be an array of strings" do
         expect do
-          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_src: "steve"))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_src: "steve", script_src: SecureHeaders::OPT_OUT))
+        end.to raise_error(ContentSecurityPolicyConfigError, "default_src must be an array of strings")
+      end
+
+      it "disallows semicolons in configs" do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_src: %w('self'), script_src: %w(mycdn.com), object_src: ["http://foo.com ; script-src *"]))
+        end.to raise_error(ContentSecurityPolicyConfigError, %(object_src contains a ";" in "http://foo.com ; script-src *"))
+      end
+
+      it "disallows newlines in configs" do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_src: %w('self'), script_src: %w(mycdn.com), object_src: ["http://foo.com \n script-src *"]))
+        end.to raise_error(ContentSecurityPolicyConfigError, %r{object_src contains a "\\n" in "http://foo.com \\n script-src})
       end
 
       it "allows nil values" do
@@ -113,20 +125,20 @@ module SecureHeaders
       it "rejects unknown directives / config" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_src: %w('self'), default_src_totally_mispelled: "steve"))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, "Unknown config directive: default_src_totally_mispelled=steve")
       end
 
       # this is mostly to ensure people don't use the antiquated shorthands common in other configs
       it "performs light validation on source lists" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_src: %w(self none inline eval), script_src: %w('self')))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, "default_src contains an invalid keyword source (self). This value must be single quoted.")
       end
 
       it "rejects anything not of the form allow-* as a sandbox value" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(sandbox: ["steve"])))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, "sandbox must be True or an array of zero or more sandbox token strings (ex. allow-forms)")
       end
 
       it "accepts anything of the form allow-* as a sandbox value " do
@@ -144,7 +156,7 @@ module SecureHeaders
       it "rejects anything not of the form type/subtype as a plugin-type value" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(plugin_types: ["steve"])))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, "plugin_types must be an array of valid media types (ex. application/pdf)")
       end
 
       it "accepts anything of the form type/subtype as a plugin-type value " do
@@ -156,7 +168,7 @@ module SecureHeaders
       it "doesn't allow report_only to be set in a non-report-only config" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(report_only: true)))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, "Only the csp_report_only config should set :report_only to true")
       end
 
       it "allows report_only to be set in a report-only config" do
@@ -253,7 +265,7 @@ module SecureHeaders
         default_policy = Configuration.dup
         expect do
           ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, script_src: %w(anothercdn.com))
-        end.to raise_error(ContentSecurityPolicyConfigError)
+        end.to raise_error(ContentSecurityPolicyConfigError, "Attempted to override an opt-out CSP config.")
       end
     end
   end

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -149,6 +149,20 @@ module SecureHeaders
           expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; script-src mycdn.com 'unsafe-inline' anothercdn.com")
         end
 
+        it "raises errors if append includes a semicolon" do
+          Configuration.default do |config|
+            config.csp = {
+              default_src: %w('self'),
+              script_src: %w(mycdn.com 'unsafe-inline')
+            }
+          end
+
+          SecureHeaders.append_content_security_policy_directives(request, script_src: ["anothercdn.com", ";object-src *"])
+          expect do
+            SecureHeaders.header_hash_for(request)
+          end.to raise_error(ContentSecurityPolicyConfigError, %(script_src contains a ";" in ";object-src *"))
+        end
+
         it "supports named appends" do
           Configuration.default do |config|
             config.csp = {
@@ -208,6 +222,20 @@ module SecureHeaders
           SecureHeaders.override_content_security_policy_directives(request, default_src: %w('none'))
           hash = SecureHeaders.header_hash_for(request)
           expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'none'; script-src 'self'")
+        end
+
+        it "raises errors if override includes a semicolon" do
+          Configuration.default do |config|
+            config.csp = {
+              default_src: %w('self'),
+              script_src: %w(mycdn.com 'unsafe-inline')
+            }
+          end
+
+          SecureHeaders.override_content_security_policy_directives(request, script_src: ["anothercdn.com", ";object-src *"])
+          expect do
+            SecureHeaders.header_hash_for(request)
+          end.to raise_error(ContentSecurityPolicyConfigError, %(script_src contains a ";" in ";object-src *"))
         end
 
         it "overrides non-existant directives" do


### PR DESCRIPTION
A followup to https://github.com/twitter/secure_headers/issues/418, instead of safely escaping bad values reject them at time of use. This applies to static configurations at boot time and dynamic configurations as well. All policies flow through the validation.

In a breaking release, we can start raising errors when encountering these misconfigurations and/or malicious attempts.

In adding additional validation, I tightened up the assertions a bit so we don't have tests passing when they shouldn't.